### PR TITLE
Fixed use of numeric value as if it were a string with []

### DIFF
--- a/Classes/PHPExcel/Cell/DefaultValueBinder.php
+++ b/Classes/PHPExcel/Cell/DefaultValueBinder.php
@@ -79,7 +79,7 @@ class PHPExcel_Cell_DefaultValueBinder implements PHPExcel_Cell_IValueBinder
             return PHPExcel_Cell_DataType::TYPE_STRING;
         } elseif ($pValue instanceof PHPExcel_RichText) {
             return PHPExcel_Cell_DataType::TYPE_INLINE;
-        } elseif ($pValue[0] === '=' && strlen($pValue) > 1) {
+        } elseif (is_string($pValue) && strlen($pValue) > 1 && "=" === $pValue[0]) {
             return PHPExcel_Cell_DataType::TYPE_FORMULA;
         } elseif (is_bool($pValue)) {
             return PHPExcel_Cell_DataType::TYPE_BOOL;


### PR DESCRIPTION
When attempting to get first char, code was not checking for string type before treating as if
it were. Now includes type check.